### PR TITLE
feat(status): tunnels flip to Provisioned after successful push

### DIFF
--- a/changes/provisioned-status.changed
+++ b/changes/provisioned-status.changed
@@ -1,0 +1,1 @@
+Changed the post-push VPNTunnel status from Active to Provisioned — configured on the NRTC side and ready to be brought up, with no operational claim. The tunnel-status PSK latch accepts legacy Active tunnels during rollout; seed-e2e creates the Provisioned status; the build job self-heals it on fresh installs.

--- a/development/seed_e2e.py
+++ b/development/seed_e2e.py
@@ -9,7 +9,7 @@ Creates (get_or_create throughout — safe to re-run):
     pinned address of the fake-cisco container in docker-compose.fake-cisco.yml)
   - Template VPNProfile "Standard-IKEv2-AES256" + Phase 1/2 policies + assignments
   - Hub VPNTunnelEndpoint (device + role "Hub") with protected prefix + crypto map CF
-  - "Planned" and "Decommissioning" statuses mapped to VPNTunnel
+  - "Planned", "Provisioned", "Decommissioning" statuses mapped to VPNTunnel
   - PortalBuildIpsecTunnel Job row enabled (disabled by default on a fresh DB;
     the portal view's enqueue would otherwise fail with RunJobTaskFailed). If
     the Job row hasn't been registered yet (registry not synced), this step
@@ -165,7 +165,7 @@ def _seed_hub_endpoint(device, namespace):
 
 def _seed_tunnel_statuses():
     vpntunnel_ct = ContentType.objects.get_for_model(VPNTunnel)
-    for status_name in ("Planned", "Decommissioning"):
+    for status_name in ("Planned", "Provisioned", "Decommissioning"):
         st, _ = Status.objects.get_or_create(name=status_name)
         st.content_types.add(vpntunnel_ct)
 
@@ -244,7 +244,7 @@ def _main():
     _seed_hub_endpoint(device, global_ns)
     print(f"  hub endpoint:     device={device.name} role=Hub prefix={HUB_PROTECTED_PREFIX}")
     _seed_tunnel_statuses()
-    print("  statuses:         Planned + Decommissioning mapped to VPNTunnel")
+    print("  statuses:         Planned + Provisioned + Decommissioning mapped to VPNTunnel")
     # Service account/token before the Job lookup: if the Job registry hasn't
     # synced yet, _seed_portal_build_job() only prints an error and moves on —
     # it must not be able to abort the run before the token gets created.

--- a/nautobot_custom_tunnel_builder/api/views.py
+++ b/nautobot_custom_tunnel_builder/api/views.py
@@ -494,7 +494,9 @@ class TunnelStatusView(APIView):
         }
 
         profile = tunnel.vpn_profile
-        if tunnel.status.name == "Active" and profile is not None:
+        # "Provisioned" is the canonical post-push status; "Active" is the
+        # legacy name still carried by tunnels built before the rename.
+        if tunnel.status.name in ("Provisioned", "Active") and profile is not None:
             # Guard the one-shot PSK latch with a row lock so two concurrent
             # GETs on a just-activated tunnel can't both read-check-write past
             # the "already retrieved" check and both return the PSK.

--- a/nautobot_custom_tunnel_builder/jobs.py
+++ b/nautobot_custom_tunnel_builder/jobs.py
@@ -746,9 +746,16 @@ class PortalBuildIpsecTunnel(Job):
                 tunnel.save()
             raise
 
-        # 5. Update tunnel status to Active on success
-        active_status = Status.objects.get_for_model(VPNTunnel).get(name="Active")
-        tunnel.status = active_status
+        # 5. Update tunnel status to Provisioned on success. Provisioned means
+        # the config is on the NRTC hub and the tunnel is ready to be brought
+        # up from the member side — it is not an operational claim.
+        # get_or_create is self-healing on fresh installs where the custom
+        # status has not been seeded yet.
+        from django.contrib.contenttypes.models import ContentType  # pylint: disable=import-outside-toplevel
+
+        provisioned_status, _ = Status.objects.get_or_create(name="Provisioned")
+        provisioned_status.content_types.add(ContentType.objects.get_for_model(VPNTunnel))
+        tunnel.status = provisioned_status
         tunnel.save()
 
         self.logger.info(

--- a/nautobot_custom_tunnel_builder/tests/test_api.py
+++ b/nautobot_custom_tunnel_builder/tests/test_api.py
@@ -171,11 +171,11 @@ def _create_hub_endpoint(device, hub_prefix_cidr="10.100.0.0/24"):
 
 
 def _ensure_vpntunnel_statuses():
-    """Ensure Planned and Decommissioning statuses are mapped to VPNTunnel."""
+    """Ensure Planned, Provisioned, and Decommissioning statuses are mapped to VPNTunnel."""
     from django.contrib.contenttypes.models import ContentType  # pylint: disable=import-outside-toplevel
 
     vpntunnel_ct = ContentType.objects.get_for_model(VPNTunnel)
-    for status_name in ("Planned", "Decommissioning"):
+    for status_name in ("Planned", "Provisioned", "Decommissioning"):
         st, _ = Status.objects.get_or_create(name=status_name)
         st.content_types.add(vpntunnel_ct)
 
@@ -626,7 +626,7 @@ class PortalTunnelCreationTest(APITestCase):  # pylint: disable=too-many-ancesto
 
     @patch(OP_MOCK_PATH, return_value="fake-op-item-id-12345")
     def test_tunnel_created_with_planned_status(self, _mock_op):
-        """New tunnels are born Planned; the build job flips them Active."""
+        """New tunnels are born Planned; the build job flips them Provisioned."""
         payload = _valid_payload(self.device, self.template_profile)
         response = self._post(PORTAL_REQUEST_URL, payload)
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
@@ -685,9 +685,9 @@ class TunnelStatusTest(APITestCase):  # pylint: disable=too-many-ancestors
 
     @staticmethod
     def _activate(tunnel_id):
-        """Simulate a successful PortalBuildIpsecTunnel run: flip Planned → Active."""
+        """Simulate a successful PortalBuildIpsecTunnel run: flip Planned → Provisioned."""
         tunnel = VPNTunnel.objects.get(pk=tunnel_id)
-        tunnel.status = Status.objects.get_for_model(VPNTunnel).get(name="Active")
+        tunnel.status = Status.objects.get_for_model(VPNTunnel).get(name="Provisioned")
         tunnel.save()
 
     def test_non_existent_tunnel_returns_404(self):
@@ -701,13 +701,13 @@ class TunnelStatusTest(APITestCase):  # pylint: disable=too-many-ancestors
     @patch(OP_MOCK_PATH, return_value="fake-op-item-id-psk-test")
     @patch("nautobot.extras.models.Secret.get_value", return_value="TestPSKReturnedOnce!")
     def test_active_tunnel_returns_psk(self, _mock_get_value, _mock_op):
-        """Status endpoint returns pre_shared_key when tunnel is Active."""
+        """Status endpoint returns pre_shared_key when tunnel is Provisioned."""
         tunnel_id = self._post_tunnel("psk-test-member", "203.0.113.77")
         self._activate(tunnel_id)
         response = self._get(TUNNEL_STATUS_URL_TEMPLATE.format(tunnel_id))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
-        self.assertEqual(data["status"], "Active")
+        self.assertEqual(data["status"], "Provisioned")
         self.assertIn("pre_shared_key", data)
         self.assertEqual(data["pre_shared_key"], "TestPSKReturnedOnce!")
 
@@ -725,7 +725,7 @@ class TunnelStatusTest(APITestCase):  # pylint: disable=too-many-ancestors
     @patch(OP_MOCK_PATH, return_value="fake-op-item-id-psk-test")
     @patch("nautobot.extras.models.Secret.get_value", return_value="TestPSKReturnedOnce!")
     def test_first_active_poll_flips_psk_retrieved_flag(self, _mock_get_value, _mock_op):
-        """The first Active poll sets custom_tunnel_builder_psk_retrieved on the profile."""
+        """The first Provisioned poll sets custom_tunnel_builder_psk_retrieved on the profile."""
         tunnel_id = self._post_tunnel("psk-flip-member", "203.0.113.79")
         self._activate(tunnel_id)
         response = self._get(TUNNEL_STATUS_URL_TEMPLATE.format(tunnel_id))
@@ -739,7 +739,7 @@ class TunnelStatusTest(APITestCase):  # pylint: disable=too-many-ancestors
     @patch(OP_MOCK_PATH, return_value="fake-op-item-id-psk-test")
     @patch("nautobot.extras.models.Secret.get_value", return_value="TestPSKReturnedOnce!")
     def test_second_poll_omits_psk(self, _mock_get_value, _mock_op):
-        """The PSK is offered exactly once; the second Active poll omits it."""
+        """The PSK is offered exactly once; the second Provisioned poll omits it."""
         tunnel_id = self._post_tunnel("psk-once-member", "203.0.113.80")
         self._activate(tunnel_id)
         first = self._get(TUNNEL_STATUS_URL_TEMPLATE.format(tunnel_id))
@@ -747,7 +747,7 @@ class TunnelStatusTest(APITestCase):  # pylint: disable=too-many-ancestors
         second = self._get(TUNNEL_STATUS_URL_TEMPLATE.format(tunnel_id))
         self.assertEqual(second.status_code, status.HTTP_200_OK)
         data = second.json()
-        self.assertEqual(data["status"], "Active")
+        self.assertEqual(data["status"], "Provisioned")
         self.assertNotIn("pre_shared_key", data)
 
     @patch(OP_MOCK_PATH, return_value="fake-op-item-id-psk-test")
@@ -764,7 +764,7 @@ class TunnelStatusTest(APITestCase):  # pylint: disable=too-many-ancestors
             response = self._get(TUNNEL_STATUS_URL_TEMPLATE.format(tunnel_id))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
-        self.assertEqual(data["status"], "Active")
+        self.assertEqual(data["status"], "Provisioned")
         self.assertNotIn("pre_shared_key", data)
 
         tunnel = VPNTunnel.objects.get(pk=tunnel_id)
@@ -777,7 +777,7 @@ class TunnelStatusTest(APITestCase):  # pylint: disable=too-many-ancestors
             response2 = self._get(TUNNEL_STATUS_URL_TEMPLATE.format(tunnel_id))
         self.assertEqual(response2.status_code, status.HTTP_200_OK)
         data2 = response2.json()
-        self.assertEqual(data2["status"], "Active")
+        self.assertEqual(data2["status"], "Provisioned")
         self.assertIn("pre_shared_key", data2)
         self.assertEqual(data2["pre_shared_key"], "RecoveredAfterOutage!")
 

--- a/nautobot_custom_tunnel_builder/tests/test_portal_job.py
+++ b/nautobot_custom_tunnel_builder/tests/test_portal_job.py
@@ -157,7 +157,7 @@ def _build_tunnel_objects():
         vpn_id="vpn-nrtc-ms-job-test-jackson-ms-001",
         name="Job Test - Jackson, MS",
     )
-    tunnel_status = Status.objects.get_for_model(VPNTunnel).get(name="Active")
+    tunnel_status = Status.objects.get_for_model(VPNTunnel).get(name="Active")  # starting state for the job under test
     tunnel = VPNTunnel.objects.create(
         name="Job Test - Jackson, MS - 3000",
         tunnel_id="vpn-tunnel-nrtc-ms-job-test-jackson-ms-3000",
@@ -287,11 +287,11 @@ class PortalJobSSHTest(TestCase):
     @patch(SECRET_GET_VALUE_PATH, return_value="TestPSK-Secret-123!")
     @patch(CONNECT_HANDLER_PATH)
     def test_tunnel_status_set_to_active_on_success(self, mock_connect, _mock_secret):
-        """Tunnel status is updated to Active after successful push."""
+        """Tunnel status is updated to Provisioned after successful push."""
         self._run_job(mock_connect, _mock_secret)
 
         self.tunnel.refresh_from_db()
-        self.assertEqual(self.tunnel.status.name, "Active")
+        self.assertEqual(self.tunnel.status.name, "Provisioned")
 
     @patch(SECRET_GET_VALUE_PATH, return_value="TestPSK-Secret-123!")
     @patch(CONNECT_HANDLER_PATH)


### PR DESCRIPTION
VPNTunnel post-push status is now **Provisioned** — configured on the NRTC side, ready to be brought up from the member side; explicitly not an operational claim (operational states like Established come with monitoring).

- `PortalBuildIpsecTunnel` sets Provisioned on success (get_or_create, self-healing on fresh installs)
- `TunnelStatusView` PSK one-shot latch keys on Provisioned; legacy Active accepted during rollout
- `seed-e2e` creates the status alongside Planned/Decommissioning
- Portal side mirrors 1:1 (member-connect-portal `feature/vpn-portal-ux`)

132/132 tests green locally (`invoke unittest`).