### PR TITLE
feat(portal-build): /32 peer prefix + one ACL permit per protected host

### DIFF
--- a/nautobot_custom_tunnel_builder/api/views.py
+++ b/nautobot_custom_tunnel_builder/api/views.py
@@ -97,11 +97,12 @@ def _get_or_create_member_device(member_name, location_slug, remote_peer_ip, loc
     # Nautobot 3.x requires a parent Prefix for every IPAddress
     members_ns = _member_namespace(member_name, tenant)
     prefix_status = Status.objects.get_for_model(Prefix).get(name="Active")
-    # Create a /24 parent prefix for the member's IP
+    # Create a /32 parent prefix scoped to just this member's peer IP — we do
+    # not model the member's surrounding /24, only the single host we peer with.
     import ipaddress as ipaddresslib  # pylint: disable=import-outside-toplevel
 
     ip_obj = ipaddresslib.ip_address(remote_peer_ip)
-    parent_network = ipaddresslib.ip_network(f"{ip_obj}/24", strict=False)
+    parent_network = ipaddresslib.ip_network(f"{ip_obj}/32", strict=False)
     Prefix.objects.get_or_create(
         prefix=str(parent_network),
         namespace=members_ns,
@@ -542,7 +543,7 @@ def _config_summary(tunnel):
             vpn_profile=profile,
             remote_peer_ip=str(spoke.source_ipaddress.address.ip) if spoke and spoke.source_ipaddress else "",
             local_network_cidr=hub_prefixes[0] if hub_prefixes else "",
-            protected_network_cidr="",
+            protected_network_cidrs=[],
             crypto_map_name="",
             sequence=sequence,
         )

--- a/nautobot_custom_tunnel_builder/jobs.py
+++ b/nautobot_custom_tunnel_builder/jobs.py
@@ -166,7 +166,9 @@ def build_iosxe_policy_config(data: dict) -> list[str]:
     ipsec_lifetime = data["ipsec_lifetime"]
 
     local_net, local_wildcard = _cidr_to_net_wildcard(data["local_network"])
-    remote_net, remote_wildcard = _cidr_to_net_wildcard(data["remote_network"])
+    # Prefer the plural `remote_networks` (one ACL permit per protected host);
+    # fall back to the legacy singular `remote_network` for the operator-UI path.
+    remote_networks = data.get("remote_networks") or [data["remote_network"]]
 
     # Phase 1: IKEv1 (ISAKMP) or IKEv2
     if ike_version == "ikev1":
@@ -174,9 +176,17 @@ def build_iosxe_policy_config(data: dict) -> list[str]:
     else:
         commands = _build_ikev2_commands(data)
 
-    # Crypto ACL (interesting traffic)
+    # Crypto ACL (interesting traffic) — one permit line per protected host,
+    # de-duplicated while preserving the order they were supplied.
     commands.append(f"ip access-list extended {acl_name}")
-    commands.append(f" permit ip {local_net} {local_wildcard} {remote_net} {remote_wildcard}")
+    seen_remotes = set()
+    for remote in remote_networks:
+        remote_net, remote_wildcard = _cidr_to_net_wildcard(remote)
+        key = (remote_net, remote_wildcard)
+        if key in seen_remotes:
+            continue
+        seen_remotes.add(key)
+        commands.append(f" permit ip {local_net} {local_wildcard} {remote_net} {remote_wildcard}")
     commands.append("exit")
 
     # IPsec Transform-Set (Phase 2)
@@ -643,14 +653,14 @@ class PortalBuildIpsecTunnel(Job):
         remote_peer_ip = str(spoke_endpoint.source_ipaddress.address.ip)
 
         hub_prefix = hub_endpoint.protected_prefixes.first()
-        spoke_prefix = spoke_endpoint.protected_prefixes.first()
+        spoke_prefixes = list(spoke_endpoint.protected_prefixes.all())
         if not hub_prefix:
             raise ValueError(f"Hub endpoint on tunnel '{tunnel.name}' has no protected prefix.")
-        if not spoke_prefix:
+        if not spoke_prefixes:
             raise ValueError(f"Spoke endpoint on tunnel '{tunnel.name}' has no protected prefix.")
 
         local_network_cidr = str(hub_prefix.prefix)
-        protected_network_cidr = str(spoke_prefix.prefix)
+        protected_network_cidrs = [str(p.prefix) for p in spoke_prefixes]
 
         # Read custom fields from VPNProfile and hub endpoint
         vpn_profile = tunnel.vpn_profile
@@ -673,7 +683,7 @@ class PortalBuildIpsecTunnel(Job):
             sequence,
             remote_peer_ip,
             local_network_cidr,
-            protected_network_cidr,
+            ",".join(protected_network_cidrs),
         )
 
         # 2. Retrieve PSK from the tunnel's SecretsGroup (stored in 1Password)
@@ -693,7 +703,7 @@ class PortalBuildIpsecTunnel(Job):
             vpn_profile=vpn_profile,
             remote_peer_ip=remote_peer_ip,
             local_network_cidr=local_network_cidr,
-            protected_network_cidr=protected_network_cidr,
+            protected_network_cidrs=protected_network_cidrs,
             crypto_map_name=crypto_map_name,
             sequence=sequence,
         )

--- a/nautobot_custom_tunnel_builder/mapping.py
+++ b/nautobot_custom_tunnel_builder/mapping.py
@@ -18,7 +18,7 @@ def profile_to_config_params(  # pylint: disable=too-many-locals,too-many-argume
     vpn_profile,
     remote_peer_ip: str,
     local_network_cidr: str,
-    protected_network_cidr: str,
+    protected_network_cidrs: list,
     crypto_map_name: str,
     sequence: int,
 ) -> dict:
@@ -28,7 +28,8 @@ def profile_to_config_params(  # pylint: disable=too-many-locals,too-many-argume
         vpn_profile: Nautobot VPNProfile model instance.
         remote_peer_ip: Remote peer IP address.
         local_network_cidr: Local network in CIDR notation.
-        protected_network_cidr: Remote (protected) network in CIDR notation.
+        protected_network_cidrs: Remote (member) protected hosts in CIDR
+            notation — one crypto-ACL permit line is rendered per entry.
         crypto_map_name: Name of the existing crypto map on the device.
         sequence: Crypto map sequence number for this tunnel.
 
@@ -62,7 +63,7 @@ def profile_to_config_params(  # pylint: disable=too-many-locals,too-many-argume
         "ike_version": ike_version,
         "remote_peer_ip": remote_peer_ip,
         "local_network": local_network_cidr,
-        "remote_network": protected_network_cidr,
+        "remote_networks": list(protected_network_cidrs),
         "crypto_map_name": crypto_map_name,
         "crypto_map_sequence": sequence,
         "crypto_acl_name": f"PORTAL-ACL-{sequence}",

--- a/nautobot_custom_tunnel_builder/tests/test_api.py
+++ b/nautobot_custom_tunnel_builder/tests/test_api.py
@@ -242,7 +242,7 @@ class PortalTunnelTenancyTest(APITestCase):  # pylint: disable=too-many-ancestor
 
         ns = Namespace.objects.get(name="member-acme-corp")
         self.assertEqual(ns.tenant, self.tenant)
-        member_ip_prefix = ns.prefixes.filter(prefix="203.0.113.0/24").first()
+        member_ip_prefix = ns.prefixes.filter(prefix="203.0.113.50/32").first()
         self.assertIsNotNone(member_ip_prefix, "member IP parent prefix should live in the member namespace")
         self.assertIsNotNone(ns.prefixes.filter(prefix="192.168.1.0/24").first())
 
@@ -1009,7 +1009,7 @@ class EndToEndConfigGenerationTest(APITestCase):  # pylint: disable=too-many-anc
             vpn_profile=vpn_profile,
             remote_peer_ip=remote_peer_ip,
             local_network_cidr=local_network_cidr,
-            protected_network_cidr=protected_network_cidr,
+            protected_network_cidrs=[protected_network_cidr],
             crypto_map_name=crypto_map_name,
             sequence=sequence,
         )
@@ -1089,7 +1089,7 @@ class EndToEndConfigGenerationTest(APITestCase):  # pylint: disable=too-many-anc
             vpn_profile=profile2,
             remote_peer_ip="203.0.113.51",
             local_network_cidr=str(hub2.protected_prefixes.first().prefix),
-            protected_network_cidr=str(tunnel2.endpoint_a.protected_prefixes.first().prefix),
+            protected_network_cidrs=[str(p.prefix) for p in tunnel2.endpoint_a.protected_prefixes.all()],
             crypto_map_name=hub2._custom_field_data.get(  # pylint: disable=protected-access
                 "custom_tunnel_builder_crypto_map_name", "VPN"
             ),

--- a/nautobot_custom_tunnel_builder/tests/test_config_generation.py
+++ b/nautobot_custom_tunnel_builder/tests/test_config_generation.py
@@ -296,3 +296,42 @@ class BuildIosxePolicyConfigOrderTest(TestCase):
         commands = build_iosxe_policy_config(_ikev2_data())
         match_idx = next(i for i, c in enumerate(commands) if c.strip().startswith("match address"))
         self.assertEqual(commands[match_idx + 1], "exit")
+
+
+# ---------------------------------------------------------------------------
+# build_iosxe_policy_config — multiple remote (member) hosts
+# ---------------------------------------------------------------------------
+
+
+class BuildConfigMultipleRemoteHostsTest(TestCase):
+    """The crypto ACL must permit every protected host, not just the first."""
+
+    def test_one_permit_line_per_remote_host(self):
+        data = _ikev2_data(remote_networks=["10.0.0.5/32", "10.0.0.6/32"])
+        data.pop("remote_network", None)
+        commands = build_iosxe_policy_config(data)
+        self.assertIn(" permit ip 192.168.1.0 0.0.0.255 10.0.0.5 0.0.0.0", commands)
+        self.assertIn(" permit ip 192.168.1.0 0.0.0.255 10.0.0.6 0.0.0.0", commands)
+
+    def test_permit_lines_deduped_preserving_order(self):
+        data = _ikev2_data(remote_networks=["10.0.0.5/32", "10.0.0.5/32", "10.0.0.6/32"])
+        data.pop("remote_network", None)
+        commands = build_iosxe_policy_config(data)
+        permits = [c for c in commands if c.strip().startswith("permit ip")]
+        self.assertEqual(
+            permits,
+            [
+                " permit ip 192.168.1.0 0.0.0.255 10.0.0.5 0.0.0.0",
+                " permit ip 192.168.1.0 0.0.0.255 10.0.0.6 0.0.0.0",
+            ],
+        )
+
+    def test_remote_networks_preferred_over_singular(self):
+        data = _ikev2_data(remote_networks=["10.9.9.9/32"])  # also has remote_network 10.0.0.0/24
+        commands = build_iosxe_policy_config(data)
+        permits = [c for c in commands if c.strip().startswith("permit ip")]
+        self.assertEqual(permits, [" permit ip 192.168.1.0 0.0.0.255 10.9.9.9 0.0.0.0"])
+
+    def test_singular_remote_network_still_supported(self):
+        commands = build_iosxe_policy_config(_ikev2_data())  # remote_network 10.0.0.0/24, no plural
+        self.assertIn(" permit ip 192.168.1.0 0.0.0.255 10.0.0.0 0.0.0.255", commands)

--- a/nautobot_custom_tunnel_builder/tests/test_mapping.py
+++ b/nautobot_custom_tunnel_builder/tests/test_mapping.py
@@ -42,7 +42,7 @@ def _make_profile(phase1=None, phase2=None):
 _COMMON_KWARGS = {
     "remote_peer_ip": "203.0.113.1",
     "local_network_cidr": "192.168.1.0/24",
-    "protected_network_cidr": "10.0.0.0/24",
+    "protected_network_cidrs": ["10.0.0.0/24"],
     "crypto_map_name": "CRYPTO-MAP",
     "sequence": 10,
 }
@@ -56,7 +56,7 @@ class ProfileToConfigParamsIKEv2Test(TestCase):
         self.assertEqual(result["ike_version"], "ikev2")
         self.assertEqual(result["remote_peer_ip"], "203.0.113.1")
         self.assertEqual(result["local_network"], "192.168.1.0/24")
-        self.assertEqual(result["remote_network"], "10.0.0.0/24")
+        self.assertEqual(result["remote_networks"], ["10.0.0.0/24"])
         self.assertEqual(result["ikev2_encryption"], "aes-cbc-256")
         self.assertEqual(result["ikev2_integrity"], "sha256")
         self.assertEqual(result["ike_dh_group"], "19")
@@ -113,3 +113,17 @@ class ProfileToConfigParamsEdgeCasesTest(TestCase):
         with self.assertRaises(ValueError) as ctx:
             profile_to_config_params(vpn_profile=profile, **_COMMON_KWARGS)
         self.assertIn("Phase 2", str(ctx.exception))
+
+
+class ProfileToConfigParamsRemoteNetworksTest(TestCase):
+    """Mapping carries every protected host through as remote_networks."""
+
+    def test_multiple_protected_hosts_passed_through(self):
+        kwargs = dict(_COMMON_KWARGS)
+        kwargs.pop("protected_network_cidrs")
+        result = profile_to_config_params(
+            vpn_profile=_make_profile(),
+            protected_network_cidrs=["10.0.0.5/32", "10.0.0.6/32"],
+            **kwargs,
+        )
+        self.assertEqual(result["remote_networks"], ["10.0.0.5/32", "10.0.0.6/32"])

--- a/nautobot_custom_tunnel_builder/tests/test_portal_job.py
+++ b/nautobot_custom_tunnel_builder/tests/test_portal_job.py
@@ -271,6 +271,26 @@ class PortalJobSSHTest(TestCase):
 
     @patch(SECRET_GET_VALUE_PATH, return_value="TestPSK-Secret-123!")
     @patch(CONNECT_HANDLER_PATH)
+    def test_every_protected_host_gets_its_own_permit_line(self, mock_connect, _mock_secret):
+        """A spoke with multiple protected hosts yields one ACL permit per host."""
+        members_ns = Namespace.objects.get(name="Members")
+        extra, _ = Prefix.objects.get_or_create(
+            prefix="192.168.1.9/32",
+            namespace=members_ns,
+            defaults={"status": Status.objects.get_for_model(Prefix).get(name="Active")},
+        )
+        self.tunnel.endpoint_a.protected_prefixes.add(extra)
+
+        conn = self._run_job(mock_connect, _mock_secret)
+
+        commands = conn.send_config_set.call_args[0][0]
+        permits = [c for c in commands if c.strip().startswith("permit ip")]
+        self.assertEqual(len(permits), 2, permits)
+        self.assertTrue(any("192.168.1.0 0.0.0.255" in c for c in permits), permits)
+        self.assertTrue(any("192.168.1.9 0.0.0.0" in c for c in permits), permits)
+
+    @patch(SECRET_GET_VALUE_PATH, return_value="TestPSK-Secret-123!")
+    @patch(CONNECT_HANDLER_PATH)
     def test_psk_in_commands_but_not_logged(self, mock_connect, _mock_secret):
         """PSK appears in commands sent to device but is redacted in logs."""
         with self.assertLogs("test.portal_job", level="DEBUG") as log_ctx:


### PR DESCRIPTION
## Summary
Stacked on #46. Two related correctness fixes for the portal build path so member protected networks are modeled and configured as individual hosts.

- **`/32` peer covering prefix** — `_get_or_create_member_device` now creates a `/32` parent prefix for the member peer IP instead of a `/24`. We peer with a single host, not its surrounding subnet.
- **One crypto-ACL permit per protected host** — `build_iosxe_policy_config` renders one `permit ip <local> <wc> <host> 0.0.0.0` line per protected host via a new plural `remote_networks` (deduped, order-preserving). The legacy singular `remote_network` is still honored for the operator-UI job path.
- **Fix silent host drop** — `PortalBuildIpsecTunnel` now gathers **all** of `spoke_endpoint.protected_prefixes`, not just `.first()`. Previously every host after the first was silently dropped from the device config.
- `profile_to_config_params`: `protected_network_cidr` → `protected_network_cidrs` (list); `_config_summary` and test callers updated accordingly.

## Testing
- Full plugin suite green: **149 tests**. New coverage in `test_config_generation` (multi-host, dedup, singular fallback, plural precedence), `test_mapping` (plural passthrough), `test_portal_job` (one permit line per host), `test_api` (`/32` covering prefix).
- **Live E2E** against dev Nautobot + fake-cisco, 4 flows (IKEv2 single, IKEv2×3 hosts, IKEv1 single, IKEv2 dup+2): all reached Provisioned, PSK returned once, peer landed as `/32`, and the pushed config showed exactly one permit line per distinct host (duplicate collapsed).

## Notes
- The API intentionally does **not** enforce host-only prefixes — the portal is the gate, and the plugin still supports subnet ACLs for the operator UI.
- Base is `feature/config-summary-ikev1` (#46) to keep the diff to just this change; retarget to `develop` once the stack below merges.