### PR TITLE
feat: enrich VPN objects, managed_by system-of-record, per-tunnel teardown

### DIFF
--- a/nautobot_custom_tunnel_builder/api/urls.py
+++ b/nautobot_custom_tunnel_builder/api/urls.py
@@ -2,7 +2,7 @@
 
 from django.urls import path
 
-from .views import PortalTunnelRequestView, TunnelStatusView
+from .views import PortalTunnelRequestView, PortalTunnelTeardownView, TunnelStatusView
 
 app_name = "nautobot_custom_tunnel_builder"
 
@@ -16,5 +16,10 @@ urlpatterns = [
         "tunnel-status/<uuid:tunnel_id>/",
         TunnelStatusView.as_view(),
         name="tunnel-status",
+    ),
+    path(
+        "portal-request/<uuid:tunnel_id>/",
+        PortalTunnelTeardownView.as_view(),
+        name="portal-teardown",
     ),
 ]

--- a/nautobot_custom_tunnel_builder/api/views.py
+++ b/nautobot_custom_tunnel_builder/api/views.py
@@ -36,6 +36,17 @@ def _location_slug(city, state):
     return f"{city.lower().replace(' ', '-')}-{state.lower()}"
 
 
+def _member_role():
+    """The 'Member' role, or None if it hasn't been bootstrapped yet.
+
+    Defensive: provisioning must not fail just because the role is absent —
+    we set it when present and leave the field null otherwise. The portal
+    bootstrap scopes this role to the VPN object types before members are
+    exposed.
+    """
+    return Role.objects.filter(name="Member").first()
+
+
 def _member_namespace(member_name, tenant):
     """Per-member IPAM namespace — keeps each member's address space isolated.
 
@@ -438,14 +449,20 @@ class PortalTunnelRequestView(APIView):
                 tenant=tenant,
             )
 
-            # 3. VPN (get_or_create by member+location)
-            vpn, _ = VPN.objects.get_or_create(
+            # 3. VPN (get_or_create by member+location) — the top-level
+            # Member-Connect-owned object; stamped managed for teardown.
+            member_role = _member_role()
+            vpn, vpn_created = VPN.objects.get_or_create(
                 vpn_id=vpn_name,
                 defaults={
                     "name": f"{member_display} - {display_location}",
                     "tenant": tenant,
+                    "role": member_role,
                 },
             )
+            if vpn_created:
+                vpn._custom_field_data["member_connect_managed"] = True  # pylint: disable=protected-access
+                vpn.save()
 
             # 4. Allocate the next crypto map sequence (advisory-locked, floor 3000).
             next_seq = _allocate_crypto_map_sequence(device)
@@ -490,6 +507,12 @@ class PortalTunnelRequestView(APIView):
             profile.secrets_group = tunnel_sg
             profile.save()
 
+            # Point the VPN at this profile on first creation (a reused VPN keeps
+            # the profile from its first tunnel).
+            if vpn_created and not vpn.vpn_profile:
+                vpn.vpn_profile = profile
+                vpn.save()
+
             # 9. Create VPNTunnel — born Planned.
             tunnel_name = f"{member_display} - {display_location} - {next_seq}"
             tunnel_id_str = f"vpn-tunnel-nrtc-ms-{member_name}-{loc_slug}-{next_seq}"
@@ -501,20 +524,25 @@ class PortalTunnelRequestView(APIView):
                 vpn=vpn,
                 vpn_profile=profile,
                 tenant=tenant,
+                role=member_role,
+                encapsulation="IPsec-Tunnel",
             )
             tunnel._custom_field_data["member_connect_request_id"] = request_id  # pylint: disable=protected-access
+            tunnel._custom_field_data["member_connect_managed"] = True  # pylint: disable=protected-access
 
             # 10. Attach the pre-configured hub endpoint (endpoint_z).
             tunnel.endpoint_z = hub_endpoint
 
             # 11. Spoke VPNTunnelEndpoint (endpoint_a) — one protected prefix
             # association per entry in member_protected_prefixes.
-            spoke_role, _ = Role.objects.get_or_create(name="Spoke")
+            spoke_role = member_role or Role.objects.get_or_create(name="Spoke")[0]
             spoke_endpoint = VPNTunnelEndpoint.objects.create(
                 name=f"{member_name}-{loc_slug}",
                 role=spoke_role,
                 device=member_device,
                 source_ipaddress=member_ip,
+                vpn_profile=profile,
+                tenant=tenant,
             )
             for cidr in member_prefix_cidrs:
                 spoke_endpoint.protected_prefixes.add(_get_or_create_prefix(cidr, member_name, tenant=tenant))
@@ -566,6 +594,10 @@ def _config_summary(tunnel):
     return {
         "hub_peer_ip": str(hub.source_ipaddress.address.ip) if hub.source_ipaddress else None,
         "hub_protected_prefixes": hub_prefixes,
+        # Encapsulation as modeled on the tunnel; protocol is always ESP for the
+        # IPsec transforms this flow builds. Both are surfaced to the member.
+        "encapsulation": tunnel.encapsulation or "IPsec-Tunnel",
+        "protocol": "ESP",
         "phase1": phase1,
         "phase2": {
             "encryption": params["ipsec_encryption"],

--- a/nautobot_custom_tunnel_builder/api/views.py
+++ b/nautobot_custom_tunnel_builder/api/views.py
@@ -25,7 +25,7 @@ from rest_framework.reverse import reverse
 from rest_framework.views import APIView
 
 from ..mapping import profile_to_config_params
-from ..onepassword_utils import get_secret_provider_params, store_psk_in_1password
+from ..onepassword_utils import delete_psk_from_1password, get_secret_provider_params, store_psk_in_1password
 from .serializers import PortalTunnelRequestSerializer
 
 logger = logging.getLogger(__name__)
@@ -45,6 +45,105 @@ def _member_role():
     exposed.
     """
     return Role.objects.filter(name="Member").first()
+
+
+# The custom field recording which system owns (created and may tear down) an
+# object, and the value the portal path stamps. Teardown callers act as a
+# system and may only delete what that system manages.
+MANAGED_BY_CF = "managed_by"
+MEMBER_CONNECT_SYSTEM = "member-connect"
+
+
+class TunnelNotOwned(Exception):
+    """Raised when a teardown caller's system does not own the target tunnel."""
+
+
+def _teardown_tunnel(tunnel, as_system):
+    """Delete a tunnel and its private objects, reaping shared parents when empty.
+
+    Reaps the shared VPN/Device only when this was their last tunnel. The
+    caller acts as ``as_system``; a tunnel whose ``managed_by`` differs is
+    refused (TunnelNotOwned) so one system can never tear down another's — or a
+    hand-built, unmanaged — objects. Identity objects (tenant, contact) and the
+    shared hub endpoint are never touched. 1Password deletion happens after the
+    DB transaction commits (external, best-effort).
+    """
+    if tunnel._custom_field_data.get(MANAGED_BY_CF) != as_system:  # pylint: disable=protected-access
+        raise TunnelNotOwned(f"tunnel '{tunnel.name}' is not managed by '{as_system}'")
+
+    from nautobot.ipam.models import IPAddressToInterface  # pylint: disable=import-outside-toplevel
+
+    deleted = []
+    vpn = tunnel.vpn
+    spoke = tunnel.endpoint_a
+    profile = tunnel.vpn_profile
+    device = spoke.device if spoke else None
+    peer_ip = spoke.source_ipaddress if spoke else None
+    secrets_group = profile.secrets_group if profile else None
+
+    # Resolve the 1Password item id from the secret before deleting it.
+    op_item_id = None
+    if secrets_group and secrets_group.secrets.exists():
+        params = secrets_group.secrets.first().parameters or {}
+        op_item_id = params.get("item") or (params.get("path") or "").rsplit("/", 1)[-1] or None
+
+    with transaction.atomic():
+        # Tunnel first — clears its FKs to vpn / profile / endpoints.
+        tunnel.delete()
+        deleted.append("vpntunnel")
+        if spoke:
+            spoke.delete()
+            deleted.append("vpntunnelendpoint")
+
+        # The parent VPN holds a PROTECT FK to a profile, so resolve it before
+        # deleting this tunnel's profile: reap the VPN when this was its last
+        # tunnel, otherwise repoint it at a surviving tunnel's profile.
+        if vpn and not vpn.vpn_tunnels.exists():
+            vpn.delete()
+            deleted.append("vpn")
+        elif vpn and profile and vpn.vpn_profile_id == profile.pk:
+            surviving = vpn.vpn_tunnels.first()
+            vpn.vpn_profile = surviving.vpn_profile if surviving else None
+            vpn.save()
+
+        if profile:
+            profile.delete()
+            deleted.append("vpnprofile")
+        if secrets_group:
+            for secret in list(secrets_group.secrets.all()):
+                secret.delete()
+                deleted.append("secret")
+            secrets_group.delete()
+            deleted.append("secretsgroup")
+
+        # Peer IP + its per-peer interface (private to this tunnel's peer).
+        if peer_ip:
+            interfaces = [a.interface for a in IPAddressToInterface.objects.filter(ip_address=peer_ip)]
+            IPAddressToInterface.objects.filter(ip_address=peer_ip).delete()
+            peer_ip.delete()
+            deleted.append("ipaddress")
+            for intf in interfaces:
+                if not IPAddressToInterface.objects.filter(interface=intf).exists():
+                    intf.delete()
+                    deleted.append("interface")
+
+        # Reap the member device once no endpoints or interfaces remain on it.
+        if (
+            device
+            and not VPNTunnelEndpoint.objects.filter(device=device).exists()
+            and not Interface.objects.filter(device=device).exists()
+        ):
+            device.delete()
+            deleted.append("device")
+
+    if op_item_id:
+        try:
+            delete_psk_from_1password(op_item_id)
+            deleted.append("1password-item")
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.exception("Teardown: failed to delete 1Password item '%s' (now orphaned).", op_item_id)
+
+    return {"deleted": deleted}
 
 
 def _member_namespace(member_name, tenant):
@@ -461,7 +560,7 @@ class PortalTunnelRequestView(APIView):
                 },
             )
             if vpn_created:
-                vpn._custom_field_data["member_connect_managed"] = True  # pylint: disable=protected-access
+                vpn._custom_field_data["managed_by"] = "member-connect"  # pylint: disable=protected-access
                 vpn.save()
 
             # 4. Allocate the next crypto map sequence (advisory-locked, floor 3000).
@@ -528,7 +627,7 @@ class PortalTunnelRequestView(APIView):
                 encapsulation="IPsec-Tunnel",
             )
             tunnel._custom_field_data["member_connect_request_id"] = request_id  # pylint: disable=protected-access
-            tunnel._custom_field_data["member_connect_managed"] = True  # pylint: disable=protected-access
+            tunnel._custom_field_data["managed_by"] = "member-connect"  # pylint: disable=protected-access
 
             # 10. Attach the pre-configured hub endpoint (endpoint_z).
             tunnel.endpoint_z = hub_endpoint
@@ -664,3 +763,35 @@ class TunnelStatusView(APIView):
                             locked_profile.save(update_fields=["_custom_field_data"])
 
         return Response(payload)
+
+
+class PortalTunnelTeardownView(APIView):
+    """Tear down a Member-Connect-managed tunnel and its private objects.
+
+    This is the Member Connect teardown surface, so it acts as the
+    ``member-connect`` system: it will only remove tunnels that system manages.
+    A tunnel managed by another system — or none — returns the same 404 as a
+    missing tunnel, so the endpoint never leaks or touches what it doesn't own.
+    """
+
+    authentication_classes = [TokenAuthentication, SessionAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def delete(self, request, tunnel_id):
+        """Delete the tunnel if the caller may delete VPNTunnels and it is ours."""
+        if not request.user.has_perm("vpn.delete_vpntunnel"):
+            return Response(
+                {"detail": "You do not have permission to delete tunnels."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        try:
+            tunnel = VPNTunnel.objects.restrict(request.user, "delete").get(pk=tunnel_id)
+        except VPNTunnel.DoesNotExist:
+            return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
+
+        try:
+            summary = _teardown_tunnel(tunnel, as_system=MEMBER_CONNECT_SYSTEM)
+        except TunnelNotOwned:
+            return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
+
+        return Response({"tunnel_id": str(tunnel_id), **summary}, status=status.HTTP_200_OK)

--- a/nautobot_custom_tunnel_builder/onepassword_utils.py
+++ b/nautobot_custom_tunnel_builder/onepassword_utils.py
@@ -95,6 +95,39 @@ def get_secret_provider_params(op_item_id):
     return "one-password", {"vault": os.environ.get("OP_VAULT_UUID", ""), "item": op_item_id, "field": "password"}
 
 
+def delete_psk_from_1password(op_item_id):
+    """Delete the 1Password item holding a tunnel's PSK (used on teardown).
+
+    Best-effort: callers treat failure as non-fatal and log it, since an
+    orphaned secret is preferable to a failed teardown. In dev bypass mode the
+    backing temp file is removed instead.
+    """
+    if not op_item_id:
+        return
+    if _dev_bypass_enabled():
+        path = os.path.join(_DEV_PSK_DIR, op_item_id)
+        if os.path.exists(path):  # noqa: PTH110
+            os.remove(path)  # noqa: PTH107
+            logger.warning("DEV BYPASS: removed PSK temp file %s", path)
+        return
+    asyncio.run(_delete_op_item(op_item_id))
+
+
+async def _delete_op_item(op_item_id):
+    """Async helper to delete a 1Password item via the SDK."""
+    from onepassword import Client  # pylint: disable=import-outside-toplevel,import-error
+
+    from . import __version__  # pylint: disable=import-outside-toplevel
+
+    op_client = await Client.authenticate(
+        auth=OP_SERVICE_ACCOUNT_TOKEN,
+        integration_name="nautobot-custom-tunnel-builder",
+        integration_version=__version__,
+    )
+    logger.info("Deleting 1Password item '%s' from vault '%s'.", op_item_id, OP_VAULT_UUID)
+    await op_client.items.delete(OP_VAULT_UUID, op_item_id)
+
+
 def _store_psk_dev_bypass(psk, member_name, location_slug, sequence):
     """Dev bypass: write PSK to a temp file, return a stable item ID."""
     os.makedirs(_DEV_PSK_DIR, exist_ok=True)

--- a/nautobot_custom_tunnel_builder/tests/test_api.py
+++ b/nautobot_custom_tunnel_builder/tests/test_api.py
@@ -469,10 +469,10 @@ class PortalTunnelCreationTest(APITestCase):  # pylint: disable=too-many-ancesto
         # Enrichment: Member Connect fills in the modeling fields it can.
         self.assertEqual(vpn.role.name, "Member")
         self.assertEqual(vpn.vpn_profile, tunnel.vpn_profile)
-        self.assertTrue(vpn._custom_field_data.get("member_connect_managed"))  # pylint: disable=protected-access
+        self.assertEqual(vpn._custom_field_data.get("managed_by"), "member-connect")  # pylint: disable=protected-access
         self.assertEqual(tunnel.role.name, "Member")
         self.assertEqual(tunnel.encapsulation, "IPsec-Tunnel")
-        self.assertTrue(tunnel._custom_field_data.get("member_connect_managed"))  # pylint: disable=protected-access
+        self.assertEqual(tunnel._custom_field_data.get("managed_by"), "member-connect")  # pylint: disable=protected-access
         self.assertEqual(tunnel.endpoint_a.role.name, "Member")
         self.assertEqual(tunnel.endpoint_a.vpn_profile, tunnel.vpn_profile)
 
@@ -529,7 +529,7 @@ class PortalTunnelCreationTest(APITestCase):  # pylint: disable=too-many-ancesto
         self.assertEqual(tunnel.role.name, "Member")
         self.assertEqual(tunnel.vpn.role.name, "Member")
         self.assertEqual(tunnel.encapsulation, "IPsec-Tunnel")
-        self.assertTrue(tunnel._custom_field_data.get("member_connect_managed"))  # pylint: disable=protected-access
+        self.assertEqual(tunnel._custom_field_data.get("managed_by"), "member-connect")  # pylint: disable=protected-access
 
     @patch(OP_MOCK_PATH, return_value="fake-op-item-id-12345")
     def test_202_response_pins_full_contract_body(self, _mock_op):
@@ -1173,3 +1173,104 @@ class EndToEndConfigGenerationTest(APITestCase):  # pylint: disable=too-many-anc
         resolved_device = assignment.interface.device
         self.assertEqual(resolved_device.pk, self.device.pk)
         self.assertEqual(resolved_device.name, "csr-vpn-router")
+
+
+TEARDOWN_URL_TEMPLATE = "/plugins/tunnel-builder/api/portal-request/{}/"
+OP_DELETE_PATH = "nautobot_custom_tunnel_builder.api.views.delete_psk_from_1password"
+
+
+class PortalTunnelTeardownTest(APITestCase):  # pylint: disable=too-many-ancestors
+    """DELETE tears down a member-connect tunnel and its private objects,
+    reaping the shared VPN/Device only when empty, and refusing cross-system."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.device = _create_test_device()
+        cls.template_profile = _create_template_vpn_profile()
+        manufacturer, _ = Manufacturer.objects.get_or_create(name="Generic")
+        DeviceType.objects.get_or_create(model="Member VPN Endpoint", manufacturer=manufacturer)
+        LocationType.objects.get_or_create(name="Site")
+        _create_hub_endpoint(cls.device)
+        _ensure_vpntunnel_statuses()
+        _ensure_member_role()
+
+    def setUp(self):
+        super().setUp()
+        self.add_permissions("vpn.add_vpntunnel", "vpn.delete_vpntunnel")
+
+    def _post(self, url, data=None):
+        return self.client.post(url, data=data or {}, format="json", **self.header)
+
+    def _provision(self, peer, rid=None):
+        payload = _valid_payload(self.device, self.template_profile, request_id=rid)
+        payload["remote_peer_ip"] = peer
+        resp = self._post(PORTAL_REQUEST_URL, payload)
+        self.assertEqual(resp.status_code, status.HTTP_202_ACCEPTED, resp.content)
+        return resp.json()["tunnel_id"]
+
+    @patch(OP_DELETE_PATH)
+    @patch(OP_MOCK_PATH, return_value="op-item-teardown")
+    def test_teardown_removes_tunnel_and_private_objects(self, _mock_op, mock_del):
+        tid = self._provision("203.0.113.70")
+        tunnel = VPNTunnel.objects.get(pk=tid)
+        vpn_pk, profile_pk, spoke_pk = tunnel.vpn_id, tunnel.vpn_profile_id, tunnel.endpoint_a_id
+        sg = tunnel.vpn_profile.secrets_group
+        sg_pk = sg.pk
+        hub_pk = tunnel.endpoint_z_id
+
+        resp = self.client.delete(TEARDOWN_URL_TEMPLATE.format(tid), **self.header)
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK, resp.content)
+        self.assertFalse(VPNTunnel.objects.filter(pk=tid).exists())
+        self.assertFalse(VPNProfile.objects.filter(pk=profile_pk).exists())
+        self.assertFalse(VPNTunnelEndpoint.objects.filter(pk=spoke_pk).exists())
+        self.assertFalse(VPN.objects.filter(pk=vpn_pk).exists(), "VPN should be reaped (last tunnel)")
+        from nautobot.extras.models import SecretsGroup  # pylint: disable=import-outside-toplevel
+
+        self.assertFalse(SecretsGroup.objects.filter(pk=sg_pk).exists())
+        # Hub endpoint (shared NRTC infra) must survive.
+        self.assertTrue(VPNTunnelEndpoint.objects.filter(pk=hub_pk).exists())
+        # 1Password item deleted (best-effort external call).
+        mock_del.assert_called_once_with("op-item-teardown")
+
+    @patch(OP_DELETE_PATH)
+    @patch(OP_MOCK_PATH, return_value="op-item-shared")
+    def test_teardown_keeps_shared_vpn_and_device_when_another_tunnel_exists(self, _mock_op, _mock_del):
+        tid1 = self._provision("203.0.113.71")
+        tid2 = self._provision("203.0.113.72")
+        vpn_pk = VPNTunnel.objects.get(pk=tid1).vpn_id
+        device_pk = VPNTunnel.objects.get(pk=tid1).endpoint_a.device_id
+
+        resp = self.client.delete(TEARDOWN_URL_TEMPLATE.format(tid1), **self.header)
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK, resp.content)
+        self.assertFalse(VPNTunnel.objects.filter(pk=tid1).exists())
+        self.assertTrue(VPNTunnel.objects.filter(pk=tid2).exists())
+        self.assertTrue(VPN.objects.filter(pk=vpn_pk).exists(), "VPN shared with tunnel 2 must survive")
+        self.assertTrue(Device.objects.filter(pk=device_pk).exists(), "Device shared with tunnel 2 must survive")
+
+    @patch(OP_DELETE_PATH)
+    @patch(OP_MOCK_PATH, return_value="op-item-xsys")
+    def test_teardown_refuses_cross_system_tunnel(self, _mock_op, mock_del):
+        tid = self._provision("203.0.113.73")
+        tunnel = VPNTunnel.objects.get(pk=tid)
+        tunnel._custom_field_data["managed_by"] = "custom-tunnel-builder"  # pylint: disable=protected-access
+        tunnel.save()
+
+        resp = self.client.delete(TEARDOWN_URL_TEMPLATE.format(tid), **self.header)
+
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertTrue(VPNTunnel.objects.filter(pk=tid).exists(), "must not delete another system's tunnel")
+        mock_del.assert_not_called()
+
+    @patch(OP_DELETE_PATH)
+    @patch(OP_MOCK_PATH, return_value="op-item-perm")
+    def test_teardown_requires_delete_permission(self, _mock_op, _mock_del):
+        tid = self._provision("203.0.113.74")
+        self.user.object_permissions.clear()
+        self.user.refresh_from_db()
+
+        resp = self.client.delete(TEARDOWN_URL_TEMPLATE.format(tid), **self.header)
+
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertTrue(VPNTunnel.objects.filter(pk=tid).exists())

--- a/nautobot_custom_tunnel_builder/tests/test_api.py
+++ b/nautobot_custom_tunnel_builder/tests/test_api.py
@@ -196,6 +196,19 @@ def _valid_payload(device, template_profile, request_id=None):
     }
 
 
+def _ensure_member_role():
+    """The 'Member' role, scoped to the VPN objects the flow stamps with it.
+
+    Mirrors what the portal bootstrap guarantees in a real deployment.
+    """
+    from django.contrib.contenttypes.models import ContentType  # pylint: disable=import-outside-toplevel
+
+    role, _ = Role.objects.get_or_create(name="Member")
+    for model in (VPN, VPNTunnel, VPNTunnelEndpoint):
+        role.content_types.add(ContentType.objects.get_for_model(model))
+    return role
+
+
 class PortalTunnelTenancyTest(APITestCase):  # pylint: disable=too-many-ancestors
     """A supplied tenant is assigned to the objects the flow creates, and each
     member gets its own IPAM namespace."""
@@ -209,6 +222,7 @@ class PortalTunnelTenancyTest(APITestCase):  # pylint: disable=too-many-ancestor
         LocationType.objects.get_or_create(name="Site")
         _create_hub_endpoint(cls.device)
         _ensure_vpntunnel_statuses()
+        _ensure_member_role()
         cls.tenant = Tenant.objects.create(name="Acme Corp Tenant")
 
     def setUp(self):
@@ -229,6 +243,8 @@ class PortalTunnelTenancyTest(APITestCase):  # pylint: disable=too-many-ancestor
         self.assertEqual(tunnel.tenant, self.tenant)
         self.assertEqual(tunnel.vpn.tenant, self.tenant)
         self.assertEqual(tunnel.vpn_profile.tenant, self.tenant)
+        # The spoke endpoint is created by the flow, so it carries the tenant too.
+        self.assertEqual(tunnel.endpoint_a.tenant, self.tenant)
         member_device = Device.objects.get(name="member-acme-corp-jackson-ms")
         self.assertEqual(member_device.tenant, self.tenant)
 
@@ -405,6 +421,7 @@ class PortalTunnelCreationTest(APITestCase):  # pylint: disable=too-many-ancesto
         # Pre-configure hub endpoint with protected prefix (required before portal can provision)
         _create_hub_endpoint(cls.device)
         _ensure_vpntunnel_statuses()
+        _ensure_member_role()
 
     def setUp(self):
         super().setUp()
@@ -449,6 +466,16 @@ class PortalTunnelCreationTest(APITestCase):  # pylint: disable=too-many-ancesto
         self.assertEqual(tunnel.vpn, vpn)
         self.assertIn("Acme Corp - Jackson, MS - 3000", tunnel.name)
 
+        # Enrichment: Member Connect fills in the modeling fields it can.
+        self.assertEqual(vpn.role.name, "Member")
+        self.assertEqual(vpn.vpn_profile, tunnel.vpn_profile)
+        self.assertTrue(vpn._custom_field_data.get("member_connect_managed"))  # pylint: disable=protected-access
+        self.assertEqual(tunnel.role.name, "Member")
+        self.assertEqual(tunnel.encapsulation, "IPsec-Tunnel")
+        self.assertTrue(tunnel._custom_field_data.get("member_connect_managed"))  # pylint: disable=protected-access
+        self.assertEqual(tunnel.endpoint_a.role.name, "Member")
+        self.assertEqual(tunnel.endpoint_a.vpn_profile, tunnel.vpn_profile)
+
         # Verify VPNProfile cloned (not the template)
         profile = tunnel.vpn_profile
         self.assertNotEqual(profile.pk, self.template_profile.pk)
@@ -487,6 +514,22 @@ class PortalTunnelCreationTest(APITestCase):  # pylint: disable=too-many-ancesto
 
         # Verify 1Password was called
         _mock_op.assert_called_once()
+
+    @patch(OP_MOCK_PATH, return_value="fake-op-no-role")
+    def test_provisioning_succeeds_when_member_role_unscoped(self, _mock_op):
+        """Provisioning must not depend on the content-type bootstrap having run:
+        an unscoped Member role is still assigned to the objects it stamps."""
+        Role.objects.get(name="Member").content_types.clear()
+        payload = _valid_payload(self.device, self.template_profile)
+        payload["remote_peer_ip"] = "203.0.113.77"
+        response = self._post(PORTAL_REQUEST_URL, payload)
+
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        tunnel = VPNTunnel.objects.get(pk=response.json()["tunnel_id"])
+        self.assertEqual(tunnel.role.name, "Member")
+        self.assertEqual(tunnel.vpn.role.name, "Member")
+        self.assertEqual(tunnel.encapsulation, "IPsec-Tunnel")
+        self.assertTrue(tunnel._custom_field_data.get("member_connect_managed"))  # pylint: disable=protected-access
 
     @patch(OP_MOCK_PATH, return_value="fake-op-item-id-12345")
     def test_202_response_pins_full_contract_body(self, _mock_op):
@@ -819,6 +862,9 @@ class TunnelStatusTest(APITestCase):  # pylint: disable=too-many-ancestors
         self.assertIsNotNone(summary, "config_summary missing from Provisioned response")
         self.assertEqual(summary["hub_peer_ip"], "10.1.1.1")
         self.assertEqual(summary["hub_protected_prefixes"], ["10.100.0.0/24"])
+        # Encapsulation + protocol are presented to the member alongside the phases.
+        self.assertEqual(summary["encapsulation"], "IPsec-Tunnel")
+        self.assertEqual(summary["protocol"], "ESP")
         p1, p2 = summary["phase1"], summary["phase2"]
         self.assertEqual(p1["ike_version"], "ikev2")
         for key in ("encryption", "integrity", "dh_group", "lifetime"):


### PR DESCRIPTION
## Summary
Three coupled changes to the portal-provisioned VPN object lifecycle.

**1. Enrich created objects** — VPN/VPNTunnel/spoke endpoint get role=Member, encapsulation (tunnel), vpn_profile, tenant; config_summary exposes encapsulation + ESP.

**2. `managed_by` system-of-record** — VPN + VPNTunnel are stamped `managed_by='member-connect'` (replaces the member_connect_managed boolean). Records the owning system so teardown is ownership-scoped.

**3. Per-tunnel teardown** — `DELETE portal-request/<tunnel_id>/`, gated on `vpn.delete_vpntunnel`. Acts as the `member-connect` system: `_teardown_tunnel` enforces `managed_by == caller-system` (404 otherwise, so it can never delete another system's or a hand-built object), deletes the tunnel + private objects (spoke endpoint, cloned profile, secret + secrets group, peer IP/interface), repoints/reaps the parent VPN (PROTECT FK) and reaps the member Device only when the last tunnel is gone, and deletes the 1Password item (best-effort). Never touches tenant/contact/hub.

## Testing
- Plugin suite: **154 green** (enrichment, config_summary, unscoped-role resilience, teardown cascade/reap/cross-system/permission).
- Live E2E: create→enrich verified; DELETE cascades + reaps VPN/device + deletes 1P item; cross-system delete returns 404 and leaves the tunnel intact.

Companion portal PR scopes the Member role + `managed_by` CF and carries the migration runbook. Requires `vpn.delete_vpntunnel` on the portal service account in prod.